### PR TITLE
fix: security 생성 후 DataInitializer, emotion enum 추가 및 컬럼 추가, weather …

### DIFF
--- a/src/main/java/com/cocomoo/taily/config/DataInitializer.java
+++ b/src/main/java/com/cocomoo/taily/config/DataInitializer.java
@@ -1,59 +1,15 @@
 package com.cocomoo.taily.config;
 
-import com.cocomoo.taily.entity.TableType;
-import com.cocomoo.taily.entity.User;
-import com.cocomoo.taily.entity.UserRole;
-import com.cocomoo.taily.entity.UserState;
-import com.cocomoo.taily.repository.DummyRepository;
-import com.cocomoo.taily.repository.TableTypeRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
-import java.util.Optional;
-
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DataInitializer implements CommandLineRunner {
 
-    private final DummyRepository dummyRepository;
-    private final TableTypeRepository tableTypeRepository;
-    private final PasswordEncoder passwordEncoder;
-
     @Override
-    @Transactional
-    public void run(String... args) {
-        if (dummyRepository.count() == 0) { // 유저가 없을 때만 생성
+    public void run(String... args) throws Exception {
 
-            // Optional import 확인: java.util.Optional
-            Optional<TableType> optionalTableType = tableTypeRepository.findById(1L);
-
-            TableType tableType = optionalTableType.orElseThrow(() ->
-                    new IllegalStateException("더미 유저 생성 실패: DB에 id=1인 TableType이 존재하지 않습니다.")
-            );
-
-            User dummy = User.builder()
-                    .publicId(UUID.randomUUID().toString())
-                    .username("testuser")
-                    .nickname("테스트유저")
-                    .password(passwordEncoder.encode("1234"))
-                    .tel("010-0000-0000")
-                    .email("test@test.com")
-                    .address("서울시")
-                    .role(UserRole.ROLE_USER)
-                    .state(UserState.ACTIVE)
-                    .tableType(tableType)
-                    .build();
-
-            dummyRepository.save(dummy);
-            log.info("더미 유저 생성 완료: {}", dummy.getUsername());
-        } else {
-            log.info("더미 유저가 이미 존재하여 생성하지 않습니다.");
-        }
     }
 }

--- a/src/main/java/com/cocomoo/taily/controller/WalkDiaryController.java
+++ b/src/main/java/com/cocomoo/taily/controller/WalkDiaryController.java
@@ -3,30 +3,31 @@ package com.cocomoo.taily.controller;
 import com.cocomoo.taily.dto.ApiResponseDto;
 import com.cocomoo.taily.dto.walkDiary.WalkDairyCreateRequestDto;
 import com.cocomoo.taily.dto.walkDiary.WalkDiaryDetailResponseDto;
+import com.cocomoo.taily.dto.walkDiary.WalkDiaryListResponseDto;
 import com.cocomoo.taily.service.WalkDiaryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
-@RequestMapping("/api/walk-dairies")
+@RequestMapping("/api/walk-diaries")
 @RequiredArgsConstructor
 @Slf4j
 public class WalkDiaryController {
     public final WalkDiaryService walkDiaryService;
 
-//    @GetMapping
-//    public ResponseEntity<?> getAllList() {
-//        log.info("게시글 리스트 조회 요청 ");
-//        List<WalkDairyResponseDto> walkDiaries = walkDiaryService.getAllList();
-//
-//        return null;
-//    }
+    @GetMapping
+    public ResponseEntity<?> getAllWalkDiaries() {
+        log.info("산책 일지 리스트 조회 요청 ");
+        List<WalkDiaryListResponseDto> walkDiaries = walkDiaryService.getAllWalkDiaries();
+        log.info("산책 일지 리스트 조회 완료 {} 건", walkDiaries.size());
+
+        return ResponseEntity.ok(ApiResponseDto.success(walkDiaries, "산책 일지 리스트 조회 성공"));
+    }
 
     @PostMapping
     public ResponseEntity<?> createWalkDiary (@RequestBody WalkDairyCreateRequestDto walkDairyCreateRequestDto) {

--- a/src/main/java/com/cocomoo/taily/dto/walkDiary/WalkDairyCreateRequestDto.java
+++ b/src/main/java/com/cocomoo/taily/dto/walkDiary/WalkDairyCreateRequestDto.java
@@ -30,4 +30,15 @@ public class WalkDairyCreateRequestDto {
     // - Spring Security에서 현재 로그인한 사용자 정보 사용
     // - SecurityContextHolder.getContext().getAuthentication()
     // - 보안상 더 안전한 방식
+
+    /**
+     * {
+     *     "date": "2025-10-01",
+     *     "walkDiaryWeather": "SUNNY",
+     *     "content": "오늘은 산책하면서 꽃이 예뻤어요.",
+     *     "beginTime": "09:00",
+     *     "endTime": "10:00",
+     *     "userId": 1
+     * }
+     */
 }

--- a/src/main/java/com/cocomoo/taily/dto/walkDiary/WalkDiaryDetailResponseDto.java
+++ b/src/main/java/com/cocomoo/taily/dto/walkDiary/WalkDiaryDetailResponseDto.java
@@ -26,6 +26,7 @@ public class WalkDiaryDetailResponseDto {
     private LocalTime endTime;
     private Long userId;
     private String username;
+    private String userNickname;
     private LocalDateTime createdAt;
 
     /**
@@ -48,6 +49,7 @@ public class WalkDiaryDetailResponseDto {
                 .endTime(walkDiary.getEndTime())
                 .userId(user.getId())
                 .username(user.getUsername())
+                .userNickname(user.getNickname())
                 .createdAt(walkDiary.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/cocomoo/taily/dto/walkDiary/WalkDiaryListResponseDto.java
+++ b/src/main/java/com/cocomoo/taily/dto/walkDiary/WalkDiaryListResponseDto.java
@@ -1,0 +1,25 @@
+package com.cocomoo.taily.dto.walkDiary;
+
+import com.cocomoo.taily.entity.WalkDiary;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class WalkDiaryListResponseDto {
+    private Long id;
+    private String content;
+    private String userNickname;
+    private LocalDateTime createdAt;
+
+    public static WalkDiaryListResponseDto from(WalkDiary walkDiary) {
+        return WalkDiaryListResponseDto.builder()
+                .id(walkDiary.getId())
+                .content(walkDiary.getContent())
+                .userNickname(walkDiary.getContent())
+                .createdAt(walkDiary.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/cocomoo/taily/entity/WalkDiary.java
+++ b/src/main/java/com/cocomoo/taily/entity/WalkDiary.java
@@ -39,6 +39,10 @@ public class WalkDiary {
     @Column(name = "end_time", nullable = false)
     private LocalTime endTime;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "emotion", nullable = false)
+    private WalkDiaryEmotion walkDiaryEmotion;
+
     @CreationTimestamp
     @Column(name= "created_at", nullable = false, updatable = false)
     private  LocalDateTime createdAt;

--- a/src/main/java/com/cocomoo/taily/entity/WalkDiaryEmotion.java
+++ b/src/main/java/com/cocomoo/taily/entity/WalkDiaryEmotion.java
@@ -1,0 +1,5 @@
+package com.cocomoo.taily.entity;
+
+public enum WalkDiaryEmotion {
+    LOVE, SMILE, NEUTRAL, SAD, ANGRY
+}

--- a/src/main/java/com/cocomoo/taily/entity/WalkDiaryWeather.java
+++ b/src/main/java/com/cocomoo/taily/entity/WalkDiaryWeather.java
@@ -1,5 +1,5 @@
 package com.cocomoo.taily.entity;
 
 public enum WalkDiaryWeather {
-    SUNNY, CLOUDY, RAINY, SNOWY, WINDY
+    SUNNY, CLOUDY, RAINY, SNOWY
 }

--- a/src/main/java/com/cocomoo/taily/repository/WalkDiaryRepository.java
+++ b/src/main/java/com/cocomoo/taily/repository/WalkDiaryRepository.java
@@ -2,8 +2,13 @@ package com.cocomoo.taily.repository;
 
 import com.cocomoo.taily.entity.WalkDiary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface WalkDiaryRepository extends JpaRepository<WalkDiary, Long> {
+    @Query("SELECT w FROM WalkDiary w JOIN FETCH w.user ORDER BY w.createdAt ASC")
+    List<WalkDiary> findAllWithUser();
 }

--- a/src/main/java/com/cocomoo/taily/service/WalkDiaryService.java
+++ b/src/main/java/com/cocomoo/taily/service/WalkDiaryService.java
@@ -2,6 +2,7 @@ package com.cocomoo.taily.service;
 
 import com.cocomoo.taily.dto.walkDiary.WalkDairyCreateRequestDto;
 import com.cocomoo.taily.dto.walkDiary.WalkDiaryDetailResponseDto;
+import com.cocomoo.taily.dto.walkDiary.WalkDiaryListResponseDto;
 import com.cocomoo.taily.entity.User;
 import com.cocomoo.taily.entity.WalkDiary;
 import com.cocomoo.taily.repository.DummyRepository;
@@ -12,6 +13,9 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -20,6 +24,21 @@ public class WalkDiaryService {
     private final WalkDiaryRepository walkDairyRepository;
     private final DummyRepository dummyRepository;
 
+    public List<WalkDiaryListResponseDto> getAllWalkDiaries() {
+        log.info("=== 산책 일지 리스트 조회 시작 ===");
+        List<WalkDiary> walkDiaries = walkDairyRepository.findAllWithUser();
+
+        log.info("조회된 산책 일지 수 : {}", walkDiaries.size());
+
+        return walkDiaries.stream().map(WalkDiaryListResponseDto::from).collect(Collectors.toList());
+    }
+
+    /**
+     * 산책 일지 작성
+     *
+     * @param walkDairyCreateRequestDto 산책 일지 작성 정보
+     * @return 생성된 산책 일지 상세 정보
+     */
     @Transactional
     public WalkDiaryDetailResponseDto createWalkDiary(WalkDairyCreateRequestDto walkDairyCreateRequestDto) {
         log.info("=== 산책 일지 작성 시작 ===");
@@ -40,4 +59,6 @@ public class WalkDiaryService {
         WalkDiary savedWalkDiary = walkDairyRepository.save(walkDiary);
         return WalkDiaryDetailResponseDto.from(savedWalkDiary);
     }
+
+
 }


### PR DESCRIPTION

# 📑 PR 요약
security 생성 후 DataInitializer, emotion enum 추가 및 컬럼 추가, weather 갯수 변경, list 기능 구현 중

## 🔗 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->

## ☑ 작업 내용

- security 관련 코드 변경 후 더미로 값을 넣었던 코드(DataInitializer 등)들 삭제 및 이전으로 복원
- 산책 일지 entity emotion 컬럼 추가 및 emotion enum 추가
- 산책 일지 weather 갯수 4개로 변경
- list 기능 구현 중

## 단위 테스트 결과

- 사진 첨부

## ✅ 기타 사항
