### PR TITLE
fix: 산책 일지 조회 기본 리스트 출력 코드 -> 년도, 달 별로 출력 되도록 코드 변경

### DIFF
--- a/src/main/java/com/cocomoo/taily/controller/WalkDiaryController.java
+++ b/src/main/java/com/cocomoo/taily/controller/WalkDiaryController.java
@@ -23,9 +23,13 @@ public class WalkDiaryController {
     public final WalkDiaryService walkDiaryService;
 
     @GetMapping
-    public ResponseEntity<?> getAllWalkDiaries() {
+    public ResponseEntity<?> getWalkDiaryByMonth(@RequestParam int year, @RequestParam int month) {
         log.info("산책 일지 리스트 조회 요청 ");
-        List<WalkDiaryListResponseDto> walkDiaries = walkDiaryService.getAllWalkDiaries();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        String username = authentication.getName();
+
+        List<WalkDiaryListResponseDto> walkDiaries = walkDiaryService.getWalkDiaryByMonth(username, year, month);
         log.info("산책 일지 리스트 조회 완료 {} 건", walkDiaries.size());
 
         return ResponseEntity.ok(ApiResponseDto.success(walkDiaries, "산책 일지 리스트 조회 성공"));

--- a/src/main/java/com/cocomoo/taily/dto/walkDiary/WalkDiaryListResponseDto.java
+++ b/src/main/java/com/cocomoo/taily/dto/walkDiary/WalkDiaryListResponseDto.java
@@ -11,14 +11,14 @@ import java.time.LocalDateTime;
 public class WalkDiaryListResponseDto {
     private Long id;
     private String content;
-    private String userNickname;
+    private String username;
     private LocalDateTime createdAt;
 
     public static WalkDiaryListResponseDto from(WalkDiary walkDiary) {
         return WalkDiaryListResponseDto.builder()
                 .id(walkDiary.getId())
                 .content(walkDiary.getContent())
-                .userNickname(walkDiary.getContent())
+                .username(walkDiary.getUser().getUsername())
                 .createdAt(walkDiary.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/cocomoo/taily/repository/WalkDiaryRepository.java
+++ b/src/main/java/com/cocomoo/taily/repository/WalkDiaryRepository.java
@@ -3,18 +3,24 @@ package com.cocomoo.taily.repository;
 import com.cocomoo.taily.entity.WalkDiary;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
 public interface WalkDiaryRepository extends JpaRepository<WalkDiary, Long> {
     /**
-     * 모든 게시글을 작성자 정보와 함께 조회
+     * 달 마다 특정 날짜에 작성한 산책 일지를 작성자 정보와 함께 조회
      *
      * - N+1 문제 방지 (fetch join으로 한 번에 조회)
-     * - 게시글 목록을 보여줄 때 작성자 이름도 필요
      */
-    @Query("SELECT w FROM WalkDiary w JOIN FETCH w.user ORDER BY w.createdAt ASC")
-    List<WalkDiary> findAllWithUser();
+    @Query("SELECT w FROM WalkDiary w JOIN FETCH w.user u WHERE u.username = :username AND w.date BETWEEN :start AND :end ORDER BY w.date")
+    List<WalkDiary> findByMonth(
+            @Param("username") String username,
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end
+    );
+
 }

--- a/src/main/java/com/cocomoo/taily/service/WalkDiaryService.java
+++ b/src/main/java/com/cocomoo/taily/service/WalkDiaryService.java
@@ -14,6 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -26,9 +28,13 @@ public class WalkDiaryService {
     private final UserRepository userRepository;
     private final TableTypeRepository tableTypeRepository;
 
-    public List<WalkDiaryListResponseDto> getAllWalkDiaries() {
+    public List<WalkDiaryListResponseDto> getWalkDiaryByMonth(String username, int year, int month) {
         log.info("=== 산책 일지 리스트 조회 시작 ===");
-        List<WalkDiary> walkDiaries = walkDairyRepository.findAllWithUser();
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDate start = yearMonth.atDay(1);
+        LocalDate end = yearMonth.atEndOfMonth();
+
+        List<WalkDiary> walkDiaries = walkDairyRepository.findByMonth(username, start, end);
 
         log.info("조회된 산책 일지 수 : {}", walkDiaries.size());
 


### PR DESCRIPTION
# 📑 PR 요약
산책 일지 조회 기본 리스트 출력 코드 -> 년도, 달 별로 출력 되도록 코드 변경

## 🔗 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->

## ☑ 작업 내용
- 산책 일지 조회 기본 리스트 출력 코드 -> 년도, 달 별로 출력 되도록 코드 변경
- 기존 그냥 출력하는 리스트를 year, month param을 주어 출력할 수 있도록 코드 변경하였음

## 단위 테스트 결과
<img width="935" height="455" alt="image" src="https://github.com/user-attachments/assets/2d91cc7d-a4da-4ae8-985d-a7a481164608" />
<img width="1033" height="942" alt="image" src="https://github.com/user-attachments/assets/cc6c390c-00c9-4c4a-9346-c5f7c226b1bd" />

## ✅ 기타 사항
