### PR TITLE
feat: 산책 일지 상세 페이지 조회 기능 구현

### DIFF
--- a/src/main/java/com/cocomoo/taily/controller/WalkDiaryController.java
+++ b/src/main/java/com/cocomoo/taily/controller/WalkDiaryController.java
@@ -22,6 +22,7 @@ import java.util.List;
 public class WalkDiaryController {
     public final WalkDiaryService walkDiaryService;
 
+    // 년도, 월 별 산책 일지 조회
     @GetMapping
     public ResponseEntity<?> getWalkDiaryByMonth(@RequestParam int year, @RequestParam int month) {
         log.info("산책 일지 리스트 조회 요청 ");
@@ -35,6 +36,7 @@ public class WalkDiaryController {
         return ResponseEntity.ok(ApiResponseDto.success(walkDiaries, "산책 일지 리스트 조회 성공"));
     }
 
+    // 산책 일지 작성
     @PostMapping
     public ResponseEntity<?> createWalkDiary (@RequestBody WalkDairyCreateRequestDto walkDairyCreateRequestDto) {
         log.info("산책 일지 작성 시작");
@@ -48,4 +50,18 @@ public class WalkDiaryController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseDto.success(walkDiaryDetailResponseDto, "산책 일지가 작성되었습니다."));
     }
+
+    // 산책 일지 상세 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getWalkDiaryById(@PathVariable Long id) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        String username = authentication.getName();
+
+        WalkDiaryDetailResponseDto walkDiary = walkDiaryService.getWalkDiaryById(id, username);
+
+        log.info("산책 일지 상세 조회 성공: date={}", walkDiary.getDate());
+        return ResponseEntity.ok(ApiResponseDto.success(walkDiary, "산책 일지 상세 조회 성공"));
+    }
+
 }

--- a/src/main/java/com/cocomoo/taily/repository/WalkDiaryRepository.java
+++ b/src/main/java/com/cocomoo/taily/repository/WalkDiaryRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface WalkDiaryRepository extends JpaRepository<WalkDiary, Long> {
@@ -22,5 +23,8 @@ public interface WalkDiaryRepository extends JpaRepository<WalkDiary, Long> {
             @Param("start") LocalDate start,
             @Param("end") LocalDate end
     );
+
+    @Query("SELECT w FROM WalkDiary w JOIN FETCH w.user WHERE w.id = :id")
+    Optional<WalkDiary> findByIdWithUser(Long id);
 
 }

--- a/src/main/java/com/cocomoo/taily/service/WalkDiaryService.java
+++ b/src/main/java/com/cocomoo/taily/service/WalkDiaryService.java
@@ -28,6 +28,20 @@ public class WalkDiaryService {
     private final UserRepository userRepository;
     private final TableTypeRepository tableTypeRepository;
 
+    /**
+     * 현재 년도, 월 별로 작성한 산책 일지 조회
+     *
+     * GET http://localhost:8080/api/walk-diaries?year=2025&month=10
+     *
+     * {
+     *     "username": "tailyUser"
+     * }
+     *
+     * @param username
+     * @param year
+     * @param month
+     * @return
+     */
     public List<WalkDiaryListResponseDto> getWalkDiaryByMonth(String username, int year, int month) {
         log.info("=== 산책 일지 리스트 조회 시작 ===");
         YearMonth yearMonth = YearMonth.of(year, month);
@@ -87,5 +101,29 @@ public class WalkDiaryService {
         return WalkDiaryDetailResponseDto.from(savedWalkDiary);
     }
 
+    /**
+     * 특정 산책 일지 상세 조회
+     *
+     * GET http://localhost:8080/walk-diaries/1
+     *
+     * @param walkDiaryId
+     * @param username
+     * @return
+     */
+    @Transactional
+    public WalkDiaryDetailResponseDto getWalkDiaryById(Long walkDiaryId, String username) {
+        log.info("산책 일지 상세 조회 : id = {}", walkDiaryId);
 
+        WalkDiary walkDiary = walkDairyRepository.findByIdWithUser(walkDiaryId).orElseThrow(() -> {
+            log.info("산책 일지 상세 조회 실패: id={}", walkDiaryId);
+            return new IllegalArgumentException("존재하지 않는 산책 일지 입니다.");
+
+        });
+
+        // 이미지 조회
+
+        log.info("산책 일지 조회 성공: content={}", walkDiary.getContent());
+
+        return WalkDiaryDetailResponseDto.from(walkDiary);
+    }
 }


### PR DESCRIPTION
# 📑 PR 요약
산책 일지 상세 페이지 조회 기능 구현
## 🔗 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->

## ☑ 작업 내용
- 산책 일지 상세 페이지 조회 기능 구현

## 단위 테스트 결과
<img width="652" height="894" alt="image" src="https://github.com/user-attachments/assets/828b6b3c-b272-4733-bf95-b921f054a806" />

## ✅ 기타 사항
